### PR TITLE
Add Edgegap relay transport for Fishnet

### DIFF
--- a/Unity/Fishnet/EdgegapTransport/Core/EdgegapClientLayer.cs
+++ b/Unity/Fishnet/EdgegapTransport/Core/EdgegapClientLayer.cs
@@ -1,0 +1,91 @@
+using LiteNetLib.Utils;
+using System;
+using System.Net;
+
+namespace FishNet.Transporting.Edgegap.Client
+{
+    public class EdgegapClientLayer : LiteNetLib.Layers.PacketLayerBase
+    {
+        const int EDGEGAP_CLIENT_HEADER_LENGTH = 9;
+
+        private uint _userAuthorizationToken;
+        private uint _sessionAuthorizationToken;
+        private RelayConnectionState _prevState = RelayConnectionState.Disconnected;
+
+        public Action<RelayConnectionState, RelayConnectionState> OnStateChange;
+
+        public EdgegapClientLayer(uint userAuthorizationToken, uint sessionAuthorizationToken)
+            : base(EDGEGAP_CLIENT_HEADER_LENGTH)
+        {
+            _userAuthorizationToken = userAuthorizationToken;
+            _sessionAuthorizationToken = sessionAuthorizationToken;
+        }
+
+        public override void ProcessInboundPacket(ref IPEndPoint endPoint, ref byte[] data, ref int offset, ref int length)
+        {
+            NetDataReader reader = new NetDataReader(data, offset, length);
+
+            var messageType = (MessageType)reader.GetByte();
+
+            if (messageType == MessageType.Ping)
+            {
+                var currentState = (RelayConnectionState)reader.GetByte();
+
+                if (currentState != _prevState && OnStateChange != null)
+                {
+                    OnStateChange(_prevState, currentState);
+                }
+
+                _prevState = currentState;
+
+                length = reader.AvailableBytes;
+                offset = reader.Position;
+
+                // Just in case, if there's a Data message attached to the ping
+                if (!reader.EndOfData) ProcessInboundPacket(ref endPoint, ref data, ref offset, ref length);
+            }
+            else if (messageType == MessageType.Data)
+            {
+                length = reader.AvailableBytes;
+            }
+            else
+            {
+                // Invalid.
+                length = 0;
+                return;
+            }
+
+            Buffer.BlockCopy(data, reader.Position, data, 0, length);
+            // NetDebug.WriteForce("Client Layer: got Data of raw size: " + length);
+        }
+
+        public override void ProcessOutBoundPacket(ref IPEndPoint endPoint, ref byte[] data, ref int offset, ref int length)
+        {
+            NetDataWriter writer = new NetDataWriter(true, length + EDGEGAP_CLIENT_HEADER_LENGTH);
+
+            writer.Put(_userAuthorizationToken);
+            writer.Put(_sessionAuthorizationToken);
+
+            // Handle ping
+            // @TODO: This is still quite the hack... There might still be a better way
+            if (length == 0)
+            {
+                writer.Put((byte)MessageType.Ping);
+            }
+            else if (_prevState == RelayConnectionState.Valid)
+            {
+                writer.Put((byte)MessageType.Data);
+                writer.Put(data, offset, length);
+                // NetDebug.WriteForce("Client Layer: Sending Data with Raw length: " + length);
+            } else
+            {
+                // Drop the packet if the relay isn't ready
+                length = 0;
+            }
+
+            // Copy the modified packet to the original buffer
+            Buffer.BlockCopy(writer.Data, 0, data, 0, writer.Length);
+            length = writer.Length;
+        }
+    }
+}

--- a/Unity/Fishnet/EdgegapTransport/Core/EdgegapClientSocket.cs
+++ b/Unity/Fishnet/EdgegapTransport/Core/EdgegapClientSocket.cs
@@ -2,7 +2,6 @@ using FishNet.Transporting.Tugboat;
 using LiteNetLib;
 using System;
 using System.Collections.Generic;
-using System.Net;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using UnityEngine;
@@ -30,11 +29,6 @@ namespace FishNet.Transporting.Edgegap.Client
         /// Session authorization token for relay usage.
         /// </summary>
         private uint _sessionAuthorizationToken;
-
-        /// <summary>
-        /// Whether this client is a local client. If true, it bypasses the relay and connects directly to loopback.
-        /// </summary>
-        private bool _local = false;
 
         /// <summary>
         /// MTU sizes for each channel.
@@ -139,7 +133,7 @@ namespace FishNet.Transporting.Edgegap.Client
         }
 
         /// <summary>
-        /// Starts the client connection.
+        /// Starts the client connection through the relay.
         /// </summary>
         /// <param name="address"></param>
         /// <param name="port"></param>
@@ -171,13 +165,14 @@ namespace FishNet.Transporting.Edgegap.Client
         }
 
         /// <summary>
-        /// Starts the client connection on localhost, pypassing the relay.
-        /// This is used to reduce unecessary traffic through the relay.
+        /// Starts the client connection in direct P2P mode, bypassing the relay.
+        /// This can be used to reduce unecessary traffic through the relay.
         /// </summary>
+        /// <param name="address">The address to connect</param>
         /// <param name="localPort">The local port to connect to</param>
-        internal bool StartConnection(ushort localPort)
+        internal bool StartConnection(string address, ushort localPort)
         {
-            base.Initialize("localhost", localPort, -1);
+            base.Initialize(address, localPort, -1);
             if (base.GetConnectionState() != LocalConnectionState.Stopped)
                 return false;
 
@@ -313,7 +308,7 @@ namespace FishNet.Transporting.Edgegap.Client
         internal void IterateOutgoing()
         {
             // IterateOutgoing is called for every tick, so we can use it to send the pings
-            if (!_local) base.OnTick(_client);
+            base.OnTick(_client);
             DequeueOutgoing();
         }
 

--- a/Unity/Fishnet/EdgegapTransport/Core/EdgegapClientSocket.cs
+++ b/Unity/Fishnet/EdgegapTransport/Core/EdgegapClientSocket.cs
@@ -1,0 +1,347 @@
+using FishNet.Transporting.Tugboat;
+using LiteNetLib;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace FishNet.Transporting.Edgegap.Client
+{
+    public class EdgegapClientSocket : EdgegapCommonSocket
+    {
+        ~EdgegapClientSocket()
+        {
+            StopConnection();
+        }
+
+        public RelayConnectionState relayConnectionState = RelayConnectionState.Disconnected;
+
+        #region Private.
+        #region Configuration.
+        // authentication
+        private uint _userAuthorizationToken;
+        private uint _sessionAuthorizationToken;
+
+        /// <summary>
+        /// MTU sizes for each channel.
+        /// </summary>
+        private int _mtu;
+        #endregion
+        #region Queues.
+        /// <summary>
+        /// Changes to the sockets local connection state.
+        /// </summary>
+        private Queue<LocalConnectionState> _localConnectionStates = new Queue<LocalConnectionState>();
+        /// <summary>
+        /// Inbound messages which need to be handled.
+        /// </summary>
+        private Queue<Packet> _incoming = new Queue<Packet>();
+        /// <summary>
+        /// Outbound messages which need to be handled.
+        /// </summary>
+        private Queue<Packet> _outgoing = new Queue<Packet>();
+        #endregion
+        /// <summary>
+        /// Client socket manager.
+        /// </summary>
+        private NetManager _client;
+        /// <summary>
+        /// How long in seconds until client times from server.
+        /// </summary>
+        private int _timeout;
+        /// <summary>
+        /// PacketLayer to use with LiteNetLib.
+        /// </summary>
+        private EdgegapClientLayer _packetLayer;
+        /// <summary>
+        /// Locks the NetManager to stop it.
+        /// </summary>
+        private readonly object _stopLock = new object();
+
+        #endregion
+
+        /// <summary>
+        /// Initializes this for use.
+        /// </summary>
+        /// <param name="t"></param>
+        internal void Initialize(Transport t, int unreliableMTU)
+        {
+            base.Transport = t;
+            _mtu = unreliableMTU;
+        }
+
+        /// <summary>
+        /// Updates the Timeout value as seconds.
+        /// </summary>
+        internal void UpdateTimeout(int timeout)
+        {
+            _timeout = timeout;
+            base.UpdateTimeout(_client, timeout);
+        }
+
+        /// <summary>
+        /// Threaded operation to process client actions.
+        /// </summary>
+        private void ThreadedSocket()
+        {
+            EventBasedNetListener listener = new EventBasedNetListener();
+            listener.NetworkReceiveEvent += Listener_NetworkReceiveEvent;
+            listener.PeerConnectedEvent += Listener_PeerConnectedEvent;
+            listener.PeerDisconnectedEvent += Listener_PeerDisconnectedEvent;
+
+            _client = new NetManager(listener, _packetLayer);
+            _client.MtuOverride = (_mtu + NetConstants.FragmentedHeaderTotalSize);
+
+            UpdateTimeout(_timeout);
+
+            _localConnectionStates.Enqueue(LocalConnectionState.Starting);
+            _client.Start();
+            _client.Connect(_relay.Address.ToString(), _relay.Port, string.Empty);
+        }
+
+
+        /// <summary>
+        /// Stops the socket on a new thread.
+        /// </summary>
+        private void StopSocketOnThread()
+        {
+            if (_client == null)
+                return;
+
+            Task t = Task.Run(() =>
+            {
+                lock (_stopLock)
+                {
+                    _client?.Stop();
+                    _client = null;
+                }
+
+                //If not stopped yet also enqueue stop.
+                if (base.GetConnectionState() != LocalConnectionState.Stopped)
+                    _localConnectionStates.Enqueue(LocalConnectionState.Stopped);
+            });
+        }
+
+        /// <summary>
+        /// Starts the client connection.
+        /// </summary>
+        /// <param name="address"></param>
+        /// <param name="port"></param>
+        /// <param name="channelsCount"></param>
+        /// <param name="pollTime"></param>
+        internal bool StartConnection(string relayAddress, ushort relayPort, uint userAuthorizationToken, uint sessionAuthorizationToken, float pingInterval = EdgegapProtocol.PingInterval)
+        {
+            base.Initialize(relayAddress, relayPort, pingInterval);
+            if (base.GetConnectionState() != LocalConnectionState.Stopped)
+                return false;
+
+            SetConnectionState(LocalConnectionState.Starting, false);
+
+            //Assign properties.
+            _userAuthorizationToken = userAuthorizationToken;
+            _sessionAuthorizationToken = sessionAuthorizationToken;
+            _relay = NetUtils.MakeEndPoint(relayAddress, relayPort);
+
+            _packetLayer = new EdgegapClientLayer(userAuthorizationToken, sessionAuthorizationToken);
+            relayConnectionState = RelayConnectionState.Checking;
+
+            _packetLayer.OnStateChange += Listener_OnRelayStateChange;
+
+            ResetQueues();
+            Task t = Task.Run(() => ThreadedSocket());
+
+            return true;
+        }
+
+        private void Listener_OnRelayStateChange(RelayConnectionState prev, RelayConnectionState current)
+        {
+            relayConnectionState = current;
+
+            if (prev == current) return;
+
+            switch (current)
+            {
+                case RelayConnectionState.Valid:
+                    Debug.Log("Client: Relay state is now Valid");
+                    _localConnectionStates.Enqueue(LocalConnectionState.Started);
+                    break;
+                case RelayConnectionState.Invalid:
+                case RelayConnectionState.Error:
+                case RelayConnectionState.SessionTimeout:
+                case RelayConnectionState.Disconnected:
+                    Debug.Log("Client: Bad relay state: " + current + ". Stopping...");
+                    StopConnection();
+                    break;
+            }
+        }
+
+
+        /// <summary>
+        /// Stops the local socket.
+        /// </summary>
+        internal bool StopConnection(DisconnectInfo? info = null)
+        {
+            if (base.GetConnectionState() == LocalConnectionState.Stopped || base.GetConnectionState() == LocalConnectionState.Stopping)
+                return false;
+
+            if (info != null)
+                base.Transport.NetworkManager.Log($"Local client disconnect reason: {info.Value.Reason}.");
+
+            base.SetConnectionState(LocalConnectionState.Stopping, false);
+            relayConnectionState = RelayConnectionState.Disconnected;
+            StopSocketOnThread();
+            return true;
+        }
+
+        /// <summary>
+        /// Resets queues.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void ResetQueues()
+        {
+            _localConnectionStates.Clear();
+            base.ClearPacketQueue(ref _incoming);
+            base.ClearPacketQueue(ref _outgoing);
+        }
+
+
+        /// <summary>
+        /// Called when disconnected from the server.
+        /// </summary>
+        private void Listener_PeerDisconnectedEvent(NetPeer peer, DisconnectInfo disconnectInfo)
+        {
+            StopConnection(disconnectInfo);
+        }
+
+        /// <summary>
+        /// Called when connected to the server.
+        /// </summary>
+        private void Listener_PeerConnectedEvent(NetPeer peer)
+        {
+            _localConnectionStates.Enqueue(LocalConnectionState.Started);
+        }
+
+        /// <summary>
+        /// Called when data is received from a peer.
+        /// </summary>
+        private void Listener_NetworkReceiveEvent(NetPeer fromPeer, NetPacketReader reader, byte channel, DeliveryMethod deliveryMethod)
+        {
+            base.Listener_NetworkReceiveEvent(_incoming, fromPeer, reader, deliveryMethod, _mtu);
+        }
+
+        /// <summary>
+        /// Dequeues and processes outgoing.
+        /// </summary>
+        private void DequeueOutgoing()
+        {
+            NetPeer peer = null;
+            if (_client != null)
+                peer = _client.FirstPeer;
+            //Server connection hasn't been made.
+            if (peer == null)
+            {
+                /* Only dequeue outgoing because other queues might have
+                * relevant information, such as the local connection queue. */
+                base.ClearPacketQueue(ref _outgoing);
+            }
+            else
+            {
+                int count = _outgoing.Count;
+                for (int i = 0; i < count; i++)
+                {
+                    Packet outgoing = _outgoing.Dequeue();
+
+                    ArraySegment<byte> segment = outgoing.GetArraySegment();
+                    DeliveryMethod dm = (outgoing.Channel == (byte)Channel.Reliable) ?
+                         DeliveryMethod.ReliableOrdered : DeliveryMethod.Unreliable;
+
+                    //If over the MTU.
+                    if (outgoing.Channel == (byte)Channel.Unreliable && segment.Count > _mtu)
+                    {
+                        base.Transport.NetworkManager.LogWarning($"Client is sending of {segment.Count} length on the unreliable channel, while the MTU is only {_mtu}. The channel has been changed to reliable for this send.");
+                        dm = DeliveryMethod.ReliableOrdered;
+                    }
+
+                    peer.Send(segment.Array, segment.Offset, segment.Count, dm);
+
+                    outgoing.Dispose();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Allows for Outgoing queue to be iterated.
+        /// </summary>
+        internal void IterateOutgoing()
+        {
+            base.OnTick(_client);
+            DequeueOutgoing();
+        }
+
+        /// <summary>
+        /// Iterates the Incoming queue.
+        /// </summary>
+        internal void IterateIncoming()
+        {
+            _client?.PollEvents();
+
+            /* Run local connection states first so we can begin
+            * to read for data at the start of the frame, as that's
+            * where incoming is read. */
+            while (_localConnectionStates.Count > 0)
+                base.SetConnectionState(_localConnectionStates.Dequeue(), false);
+
+            //Not yet started, cannot continue.
+            LocalConnectionState localState = base.GetConnectionState();
+            if (localState != LocalConnectionState.Started)
+            {
+                ResetQueues();
+                //If stopped try to kill task.
+                if (localState == LocalConnectionState.Stopped)
+                {
+                    StopSocketOnThread();
+                    return;
+                }
+            }
+
+            /* Incoming. */
+            while (_incoming.Count > 0)
+            {
+                Packet incoming = _incoming.Dequeue();
+                ClientReceivedDataArgs dataArgs = new ClientReceivedDataArgs(
+                    incoming.GetArraySegment(),
+                    (Channel)incoming.Channel, base.Transport.Index);
+                base.Transport.HandleClientReceivedDataArgs(dataArgs);
+                //Dispose of packet.
+                incoming.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Sends a packet to the server.
+        /// </summary>
+        internal void SendToServer(byte channelId, ArraySegment<byte> segment)
+        {
+            //Not started, cannot send.
+            if (base.GetConnectionState() != LocalConnectionState.Started)
+                return;
+
+            //// Write relay header
+            //NetDataWriter writer = new NetDataWriter(true, segment.Count + 9);
+            //writer.Put(_userAuthorizationToken);
+            //writer.Put(_sessionAuthorizationToken);
+            //writer.Put((byte)MessageType.Data);
+            //writer.Put(segment.Array, segment.Offset, segment.Count);
+
+            //ArraySegment<byte> _segment = new ArraySegment<byte>(writer.Data, 0, writer.Length);
+            Send(ref _outgoing, channelId, segment, -1, _mtu);
+        }
+
+        public void SendPing()
+        {
+            if (_client != null) _client.SendRaw(new byte[0], 0, 0, _relay);
+        }
+    }
+}

--- a/Unity/Fishnet/EdgegapTransport/Core/EdgegapCommonSocket.cs
+++ b/Unity/Fishnet/EdgegapTransport/Core/EdgegapCommonSocket.cs
@@ -1,14 +1,9 @@
-﻿using FishNet.Utility.Performance;
-using LiteNetLib;
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
+﻿using LiteNetLib;
 using FishNet.Transporting.Tugboat;
 using System.Net;
 
 namespace FishNet.Transporting.Edgegap
 {
-
     public abstract class EdgegapCommonSocket : CommonSocket
     {
         private uint _lastPingTick = 0;
@@ -30,7 +25,9 @@ namespace FishNet.Transporting.Edgegap
             {
                 _lastPingTick = InstanceFinder.TimeManager.Tick;
 
-                // This hack is supported by the Relay Client and Server layers to detect outgoing pings
+                // This hack is supported by the Relay Client/Server layers to detect outgoing pings
+                // It's necessary since there's no way to bypass our Client/Server layer code
+                // which would consider any packet a Data packet.
                 manager.SendRaw(new byte[0], 0, 0, _relay);
             }
         }

--- a/Unity/Fishnet/EdgegapTransport/Core/EdgegapCommonSocket.cs
+++ b/Unity/Fishnet/EdgegapTransport/Core/EdgegapCommonSocket.cs
@@ -1,0 +1,39 @@
+﻿using FishNet.Utility.Performance;
+using LiteNetLib;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using FishNet.Transporting.Tugboat;
+using System.Net;
+
+namespace FishNet.Transporting.Edgegap
+{
+
+    public abstract class EdgegapCommonSocket : CommonSocket
+    {
+        private uint _lastPingTick = 0;
+        private float _pingInterval;
+
+        protected IPEndPoint _relay;
+
+        protected void Initialize(string relayAddress, ushort relayPort, float pingInterval)
+        {
+            _relay = NetUtils.MakeEndPoint(relayAddress, relayPort);
+            _pingInterval = pingInterval;
+        }
+
+        protected void OnTick(NetManager manager)
+        {
+            // Send pings
+            var timePassed = InstanceFinder.TimeManager.TimePassed(_lastPingTick);
+            if (manager != null && (timePassed > _pingInterval))
+            {
+                _lastPingTick = InstanceFinder.TimeManager.Tick;
+
+                // This hack is supported by the Relay Client and Server layers to detect outgoing pings
+                manager.SendRaw(new byte[0], 0, 0, _relay);
+            }
+        }
+    }
+
+}

--- a/Unity/Fishnet/EdgegapTransport/Core/EdgegapCommonSocket.cs
+++ b/Unity/Fishnet/EdgegapTransport/Core/EdgegapCommonSocket.cs
@@ -19,6 +19,8 @@ namespace FishNet.Transporting.Edgegap
 
         protected void OnTick(NetManager manager)
         {
+            if (_pingInterval <= 0) return;
+
             // Send pings
             var timePassed = InstanceFinder.TimeManager.TimePassed(_lastPingTick);
             if (manager != null && (timePassed > _pingInterval))

--- a/Unity/Fishnet/EdgegapTransport/Core/EdgegapProtocol.cs
+++ b/Unity/Fishnet/EdgegapTransport/Core/EdgegapProtocol.cs
@@ -1,0 +1,29 @@
+// relay protocol definitions
+namespace FishNet.Transporting.Edgegap
+{
+    public enum RelayConnectionState : byte
+    {
+        Disconnected = 0,   // until the user calls connect()
+        Checking = 1,       // recently connected, validation in progress
+        Valid = 2,          // validation succeeded
+        Invalid = 3,        // validation rejected by tower
+        SessionTimeout = 4, // session owner timed out
+        Error = 5,          // other error
+    }
+
+    public enum MessageType : byte
+    {
+        Ping = 1,
+        Data = 2
+    }
+
+    public static class EdgegapProtocol
+    {
+        // MTU: relay adds up to 13 bytes of metadata in the worst case.
+        public const int Overhead = 13;
+
+        // ping interval should be between 100 ms and 1 second.
+        // faster ping gives faster authentication, but higher bandwidth.
+        public const float PingInterval = 0.5f;
+    }
+}

--- a/Unity/Fishnet/EdgegapTransport/Core/EdgegapProtocol.cs
+++ b/Unity/Fishnet/EdgegapTransport/Core/EdgegapProtocol.cs
@@ -20,7 +20,8 @@ namespace FishNet.Transporting.Edgegap
     public static class EdgegapProtocol
     {
         // MTU: relay adds up to 13 bytes of metadata in the worst case.
-        public const int Overhead = 13;
+        public const int ServerOverhead = 13;
+        public const int ClientOverhead = 9;
 
         // ping interval should be between 100 ms and 1 second.
         // faster ping gives faster authentication, but higher bandwidth.

--- a/Unity/Fishnet/EdgegapTransport/Core/EdgegapServerLayer.cs
+++ b/Unity/Fishnet/EdgegapTransport/Core/EdgegapServerLayer.cs
@@ -1,0 +1,106 @@
+using LiteNetLib.Utils;
+using System;
+using System.Net;
+
+namespace FishNet.Transporting.Edgegap.Server
+{
+    public class EdgegapServerLayer : LiteNetLib.Layers.PacketLayerBase
+    {
+        private IPEndPoint _relay;
+        private uint _userAuthorizationToken;
+        private uint _sessionAuthorizationToken;
+        private RelayConnectionState _prevState = RelayConnectionState.Disconnected;
+
+        public Action<RelayConnectionState, RelayConnectionState> OnStateChange;
+
+        public EdgegapServerLayer(IPEndPoint relay, uint userAuthorizationToken, uint sessionAuthorizationToken)
+            : base(EdgegapProtocol.Overhead)
+        {
+            _userAuthorizationToken = userAuthorizationToken;
+            _sessionAuthorizationToken = sessionAuthorizationToken;
+
+            _relay = relay;
+        }
+
+        public override void ProcessInboundPacket(ref IPEndPoint endPoint, ref byte[] data, ref int offset, ref int length)
+        {
+            // If relay isn't active, don't touch the packet
+            if (_relay == null) return;
+
+            NetDataReader reader = new NetDataReader(data, offset, length);
+
+            var messageType = (MessageType)reader.GetByte();
+
+            if (messageType == MessageType.Ping)
+            {
+                var currentState = (RelayConnectionState)reader.GetByte();
+
+                if (currentState != _prevState && OnStateChange != null)
+                {
+                    OnStateChange(_prevState, currentState);
+                }
+
+                _prevState = currentState;
+
+                length = reader.AvailableBytes;
+                offset = reader.Position;
+
+                if (!reader.EndOfData) ProcessInboundPacket(ref endPoint, ref data, ref offset, ref length);
+            } else if (messageType == MessageType.Data)
+            {
+                var connectionId = reader.GetUInt();
+
+                // Port = 0 means it's a Virtual Address
+                endPoint.Address = new IPAddress(connectionId);
+                endPoint.Port = 0;
+
+                length = reader.AvailableBytes;
+                Buffer.BlockCopy(data, reader.Position, data, 0, length);
+
+                // NetDebug.WriteForce("Server Layer: Got message for connection ID: " + connectionId + " with Raw length: " + length);
+            } else
+            {
+                // Invalid.
+                length = 0;
+            }
+        }
+
+        public override void ProcessOutBoundPacket(ref IPEndPoint endPoint, ref byte[] data, ref int offset, ref int length)
+        {
+            // If relay isn't active, don't touch the packet
+            if (_relay == null) return;
+
+            NetDataWriter writer = new NetDataWriter(true, length + EdgegapProtocol.Overhead);
+
+            writer.Put(_userAuthorizationToken);
+            writer.Put(_sessionAuthorizationToken);
+
+            // Handle ping
+            if (length == 0)
+            {
+                writer.Put((byte)MessageType.Ping);
+            }
+            else
+            {
+                // No sense sending data if the connection isn't valid
+                if (_prevState != RelayConnectionState.Valid) return;
+
+                writer.Put((byte)MessageType.Data);
+
+#pragma warning disable CS0618 // Type or member is obsolete
+                int peerId = (int)endPoint.Address.Address;
+                // NetDebug.WriteForce("Server Layer: Sending message to Peer: " + peerId + " with raw length: " + length);
+#pragma warning restore CS0618
+                writer.Put(peerId);
+                writer.Put(data, offset, length);
+
+                // Send the packet to the relay
+                endPoint = _relay;
+            }
+
+            // Copy the modified packet to the original buffer
+            Buffer.BlockCopy(writer.Data, 0, data, 0, writer.Length);
+            length = writer.Length;
+        }
+    }
+}

--- a/Unity/Fishnet/EdgegapTransport/Core/EdgegapServerSocket.cs
+++ b/Unity/Fishnet/EdgegapTransport/Core/EdgegapServerSocket.cs
@@ -1,0 +1,504 @@
+using FishNet.Connection;
+using FishNet.Managing;
+using LiteNetLib;
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using UnityEngine;
+using FishNet.Transporting.Tugboat;
+using FishNet.Transporting.Tugboat.Server;
+using System.Net;
+
+namespace FishNet.Transporting.Edgegap.Server
+{
+    public class EdgegapServerSocket : EdgegapCommonSocket
+    {
+
+        #region Public.
+        public RelayConnectionState relayConnectionState = RelayConnectionState.Disconnected;
+
+        /// <summary>
+        /// Gets the current ConnectionState of a remote client on the server.
+        /// </summary>
+        /// <param name="connectionId">ConnectionId to get ConnectionState for.</param>
+        internal RemoteConnectionState GetConnectionState(int connectionId)
+        {
+            NetPeer peer = GetNetPeer(connectionId, false);
+            if (peer == null || peer.ConnectionState != ConnectionState.Connected)
+                return RemoteConnectionState.Stopped;
+            else
+                return RemoteConnectionState.Started;
+        }
+
+        #endregion
+
+        #region Private.
+        #region Configuration.
+        // authentication
+        private uint _userAuthorizationToken;
+        private uint _sessionAuthorizationToken;
+        /// <summary>
+        /// Maximum number of allowed clients.
+        /// </summary>
+        private int _maximumClients;
+        /// <summary>
+        /// MTU size per packet.
+        /// </summary>
+        private int _mtu;
+        #endregion
+        #region Queues.
+        /// <summary>
+        /// Changes to the sockets local connection state.
+        /// </summary>
+        private Queue<LocalConnectionState> _localConnectionStates = new Queue<LocalConnectionState>();
+        /// <summary>
+        /// Inbound messages which need to be handled.
+        /// </summary>
+        private Queue<Packet> _incoming = new Queue<Packet>();
+        /// <summary>
+        /// Outbound messages which need to be handled.
+        /// </summary>
+        private Queue<Packet> _outgoing = new Queue<Packet>();
+        /// <summary>
+        /// ConnectionEvents which need to be handled.
+        /// </summary>
+        private Queue<RemoteConnectionEvent> _remoteConnectionEvents = new Queue<RemoteConnectionEvent>();
+        #endregion
+        /// <summary>
+        /// Key required to connect.
+        /// </summary>
+        private string _key = string.Empty;
+        /// <summary>
+        /// How long in seconds until client times from server.
+        /// </summary>
+        private int _timeout;
+        /// <summary>
+        /// Server socket manager.
+        /// </summary>
+        private NetManager _server;
+        /// <summary>
+        /// PacketLayer to use with LiteNetLib.
+        /// </summary>
+        private EdgegapServerLayer _packetLayer;
+        /// <summary>
+        /// Locks the NetManager to stop it.
+        /// </summary>
+        private readonly object _stopLock = new object();
+        #endregion
+
+        ~EdgegapServerSocket()
+        {
+            StopConnection();
+        }
+
+        /// <summary>
+        /// Initializes this for use.
+        /// </summary>
+        /// <param name="t"></param>
+        internal void Initialize(Transport t, int unreliableMTU)
+        {
+            base.Transport = t;
+            _mtu = unreliableMTU;
+        }
+
+        /// <summary>
+        /// Updates the Timeout value as seconds.
+        /// </summary>
+        internal void UpdateTimeout(int timeout)
+        {
+            _timeout = timeout;
+            base.UpdateTimeout(_server, timeout);
+        }
+
+
+        /// <summary>
+        /// Threaded operation to process server actions.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void ThreadedSocket()
+        {
+            EventBasedNetListener listener = new EventBasedNetListener();
+            listener.ConnectionRequestEvent += Listener_ConnectionRequestEvent;
+            listener.PeerConnectedEvent += Listener_PeerConnectedEvent;
+            listener.NetworkReceiveEvent += Listener_NetworkReceiveEvent;
+            listener.PeerDisconnectedEvent += Listener_PeerDisconnectedEvent;
+
+            _server = new NetManager(listener, _packetLayer);
+            _server.MtuOverride = (_mtu + NetConstants.FragmentedHeaderTotalSize);
+
+            UpdateTimeout(_timeout);
+
+            _localConnectionStates.Enqueue(LocalConnectionState.Starting);
+            _server.Start();
+
+            relayConnectionState = RelayConnectionState.Checking;
+        }
+
+        /// <summary>
+        /// Stops the socket on a new thread.
+        /// </summary>
+        private void StopSocketOnThread()
+        {
+            if (_server == null)
+                return;
+
+            Task t = Task.Run(() =>
+            {
+                lock (_stopLock)
+                {
+                    _server?.Stop();
+                    _server = null;
+                }
+
+                //If not stopped yet also enqueue stop.
+                if (base.GetConnectionState() != LocalConnectionState.Stopped)
+                    _localConnectionStates.Enqueue(LocalConnectionState.Stopped);
+            });
+        }
+
+        /// <summary>
+        /// Gets the address of a remote connection Id.
+        /// </summary>
+        /// <param name="connectionId"></param>
+        /// <returns>Returns string.empty if Id is not found.</returns>
+        internal string GetConnectionAddress(int connectionId)
+        {
+            if (GetConnectionState() != LocalConnectionState.Started)
+            {
+                string msg = "Server socket is not started.";
+                if (Transport == null)
+                    NetworkManager.StaticLogWarning(msg);
+                else
+                    Transport.NetworkManager.LogWarning(msg);
+                return string.Empty;
+            }
+
+            NetPeer peer = GetNetPeer(connectionId, false);
+            if (peer == null)
+            { 
+                Transport.NetworkManager.LogWarning($"Connection Id {connectionId} returned a null NetPeer.");
+                return string.Empty;
+            }
+
+            return peer.EndPoint.Address.ToString();
+        }
+
+        /// <summary>
+        /// Returns a NetPeer for connectionId.
+        /// </summary>
+        /// <param name="connectionId"></param>
+        /// <returns></returns>
+        private NetPeer GetNetPeer(int connectionId, bool connectedOnly)
+        {
+            if (_server != null)
+            {
+                NetPeer peer = _server.GetPeerById(connectionId);
+                if (connectedOnly && peer != null && peer.ConnectionState != ConnectionState.Connected)
+                    peer = null;
+
+                return peer;
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Starts the server.
+        /// </summary>
+        internal bool StartConnection(string relayAddress, ushort relayPort, uint userAuthorizationToken, uint sessionAuthorizationToken, int maximumClients, float pingInterval = EdgegapProtocol.PingInterval)
+        {
+            base.Initialize(relayAddress, relayPort, pingInterval);
+
+            if (base.GetConnectionState() != LocalConnectionState.Stopped)
+                return false;
+
+
+            SetConnectionState(LocalConnectionState.Starting, true);
+
+            //Assign properties.
+            _userAuthorizationToken = userAuthorizationToken;
+            _sessionAuthorizationToken = sessionAuthorizationToken;
+            _maximumClients = maximumClients;
+
+            _relay = NetUtils.MakeEndPoint(relayAddress, relayPort);
+            _packetLayer = new EdgegapServerLayer(_relay, userAuthorizationToken, sessionAuthorizationToken);
+            _packetLayer.OnStateChange += Listener_OnRelayStateChange;
+
+            ResetQueues();
+
+            Task t = Task.Run(() => ThreadedSocket());
+
+            return true;
+        }
+        private void Listener_OnRelayStateChange(RelayConnectionState prev, RelayConnectionState current)
+        {
+            relayConnectionState = current;
+
+            if (prev == current) return;
+
+            switch (current)
+            {
+                case RelayConnectionState.Valid:
+                    Debug.Log("Server: Relay state is now Valid");
+                    _localConnectionStates.Enqueue(LocalConnectionState.Started);
+                    break;
+                case RelayConnectionState.Invalid:
+                case RelayConnectionState.Error:
+                case RelayConnectionState.SessionTimeout:
+                case RelayConnectionState.Disconnected:
+                    Debug.Log("Server: Bad relay state. Stopping...");
+                    StopConnection();
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Stops the local socket.
+        /// </summary>
+        internal bool StopConnection()
+        {
+            if (_server == null || base.GetConnectionState() == LocalConnectionState.Stopped || base.GetConnectionState() == LocalConnectionState.Stopping)
+                return false;
+
+            _localConnectionStates.Enqueue(LocalConnectionState.Stopping);
+            StopSocketOnThread();
+            return true;
+        }
+
+        /// <summary>
+        /// Stops a remote client disconnecting the client from the server.
+        /// </summary>
+        /// <param name="connectionId">ConnectionId of the client to disconnect.</param>
+        internal bool StopConnection(int connectionId)
+        {
+            //Server isn't running.
+            if (_server == null || base.GetConnectionState() != LocalConnectionState.Started)
+                return false;
+
+            NetPeer peer = GetNetPeer(connectionId, false);
+            if (peer == null)
+                return false;
+
+            try
+            {
+                peer.Disconnect();
+            }
+            catch
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Resets queues.
+        /// </summary>
+        private void ResetQueues()
+        {
+            _localConnectionStates.Clear();
+            base.ClearPacketQueue(ref _incoming);
+            base.ClearPacketQueue(ref _outgoing);
+            _remoteConnectionEvents.Clear();
+        }
+
+
+        /// <summary>
+        /// Called when a peer disconnects or times out.
+        /// </summary>
+        private void Listener_PeerDisconnectedEvent(NetPeer peer, DisconnectInfo disconnectInfo)
+        {
+            _remoteConnectionEvents.Enqueue(new RemoteConnectionEvent(false, peer.Id));
+        }
+
+        /// <summary>
+        /// Called when a peer completes connection.
+        /// </summary>
+        private void Listener_PeerConnectedEvent(NetPeer peer)
+        {
+            _remoteConnectionEvents.Enqueue(new RemoteConnectionEvent(true, peer.Id));
+        }
+
+        /// <summary>
+        /// Called when data is received from a peer.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void Listener_NetworkReceiveEvent(NetPeer fromPeer, NetPacketReader reader, byte channel, DeliveryMethod deliveryMethod)
+        {
+            //If over the MTU.
+            if (reader.AvailableBytes > _mtu)
+            {
+                _remoteConnectionEvents.Enqueue(new RemoteConnectionEvent(false, fromPeer.Id));
+                fromPeer.Disconnect();
+            }
+            else
+            {
+                base.Listener_NetworkReceiveEvent(_incoming, fromPeer, reader, deliveryMethod, _mtu);
+            }
+        }
+
+
+        /// <summary>
+        /// Called when a remote connection request is made.
+        /// </summary>
+        private void Listener_ConnectionRequestEvent(ConnectionRequest request)
+        {
+            if (_server == null)
+                return;
+
+            //At maximum peers.
+            if (_server.ConnectedPeersCount >= _maximumClients)
+            {
+                request.Reject();
+                return;
+            }
+
+            request.AcceptIfKey(_key);
+        }
+
+        /// <summary>
+        /// Dequeues and processes outgoing.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void DequeueOutgoing()
+        {
+            if (base.GetConnectionState() != LocalConnectionState.Started || _server == null)
+            {
+                //Not started, clear outgoing.
+                base.ClearPacketQueue(ref _outgoing);
+            }
+            else
+            {
+                int count = _outgoing.Count;
+                for (int i = 0; i < count; i++)
+                {
+                    Packet outgoing = _outgoing.Dequeue();
+                    int connectionId = outgoing.ConnectionId;
+
+                    ArraySegment<byte> segment = outgoing.GetArraySegment();
+                    DeliveryMethod dm = (outgoing.Channel == (byte)Channel.Reliable) ?
+                         DeliveryMethod.ReliableOrdered : DeliveryMethod.Unreliable;
+
+                    //If over the MTU.
+                    if (outgoing.Channel == (byte)Channel.Unreliable && segment.Count > _mtu)
+                    {
+                        base.Transport.NetworkManager.LogWarning($"Server is sending of {segment.Count} length on the unreliable channel, while the MTU is only {_mtu}. The channel has been changed to reliable for this send.");
+                        dm = DeliveryMethod.ReliableOrdered;
+                    }
+
+                    //Send to all clients.
+                    if (connectionId == NetworkConnection.UNSET_CLIENTID_VALUE)
+                    {
+                        _server.SendToAll(segment.Array, segment.Offset, segment.Count, dm);
+                    }
+                    //Send to one client.
+                    else
+                    {
+                        NetPeer peer = GetNetPeer(connectionId, true);
+                        //If peer is found.
+                        if (peer != null)
+                            peer.Send(segment.Array, segment.Offset, segment.Count, dm);
+                    }
+
+                    outgoing.Dispose();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Allows for Outgoing queue to be iterated.
+        /// </summary>
+        internal void IterateOutgoing()
+        {
+            base.OnTick(_server);
+            DequeueOutgoing();
+        }
+
+        /// <summary>
+        /// Iterates the Incoming queue.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal void IterateIncoming()
+        {
+            _server?.PollEvents();
+
+            /* Run local connection states first so we can begin
+             * to read for data at the start of the frame, as that's
+             * where incoming is read. */
+            while (_localConnectionStates.Count > 0)
+                base.SetConnectionState(_localConnectionStates.Dequeue(), true);
+
+            //Not yet started.
+            LocalConnectionState localState = base.GetConnectionState();
+            if (localState != LocalConnectionState.Started)
+            {
+                ResetQueues();
+                //If stopped try to kill task.
+                if (localState == LocalConnectionState.Stopped)
+                {
+                    StopSocketOnThread();
+                    return;
+                }
+            }
+
+            //Handle connection and disconnection events.
+            while (_remoteConnectionEvents.Count > 0)
+            {
+                RemoteConnectionEvent connectionEvent = _remoteConnectionEvents.Dequeue();
+                RemoteConnectionState state = (connectionEvent.Connected) ? RemoteConnectionState.Started : RemoteConnectionState.Stopped;
+                base.Transport.HandleRemoteConnectionState(new RemoteConnectionStateArgs(state, connectionEvent.ConnectionId, base.Transport.Index));
+            }
+
+            //Handle packets.
+            while (_incoming.Count > 0)
+            {
+                Packet incoming = _incoming.Dequeue();
+                //Make sure peer is still connected.
+                NetPeer peer = GetNetPeer(incoming.ConnectionId, true);
+                if (peer != null)
+                {
+                    ServerReceivedDataArgs dataArgs = new ServerReceivedDataArgs(
+                        incoming.GetArraySegment(),
+                        (Channel)incoming.Channel,
+                        incoming.ConnectionId,
+                        base.Transport.Index);
+
+                    base.Transport.HandleServerReceivedDataArgs(dataArgs);
+                }
+
+                incoming.Dispose();
+            }
+
+        }
+
+        /// <summary>
+        /// Sends a packet to a single, or all clients.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal void SendToClient(byte channelId, ArraySegment<byte> segment, int connectionId)
+        {
+            Send(ref _outgoing, channelId, segment, connectionId, _mtu);
+        }
+
+        /// <summary>
+        /// Returns the maximum number of clients allowed to connect to the server. If the transport does not support this method the value -1 is returned.
+        /// </summary>
+        /// <returns></returns>
+        internal int GetMaximumClients()
+        {
+            return _maximumClients;
+        }
+
+        /// <summary>
+        /// Sets the MaximumClients value.
+        /// </summary>
+        /// <param name="value"></param>
+        internal void SetMaximumClients(int value)
+        {
+            _maximumClients = value;
+        }
+    }
+}

--- a/Unity/Fishnet/EdgegapTransport/Core/EdgegapServerSocket.cs
+++ b/Unity/Fishnet/EdgegapTransport/Core/EdgegapServerSocket.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using UnityEngine;
 using FishNet.Transporting.Tugboat;
 using FishNet.Transporting.Tugboat.Server;
-using System.Net;
 
 namespace FishNet.Transporting.Edgegap.Server
 {
@@ -35,11 +34,17 @@ namespace FishNet.Transporting.Edgegap.Server
 
         #region Private.
         #region Configuration.
-        // authentication
+        /// <summary>
+        /// User authorization token for relay usage.
+        /// </summary>
         private uint _userAuthorizationToken;
+        /// <summary>
+        /// Session authorization token for relay usage.
+        /// </summary>
         private uint _sessionAuthorizationToken;
-        // local server
-        private bool _listenOnLocal;
+        /// <summary>
+        /// The local port to bind
+        /// </summary>
         private ushort _localPort;
         /// <summary>
         /// Maximum number of allowed clients.

--- a/Unity/Fishnet/EdgegapTransport/EdgegapTransport.cs
+++ b/Unity/Fishnet/EdgegapTransport/EdgegapTransport.cs
@@ -1,0 +1,488 @@
+using FishNet.Managing;
+using FishNet.Managing.Timing;
+using FishNet.Managing.Transporting;
+using FishNet.Serializing;
+using FishNet.Transporting.Edgegap.Client;
+using LiteNetLib;
+using LiteNetLib.Layers;
+using LiteNetLib.Utils;
+using System;
+using System.Runtime.CompilerServices;
+using UnityEngine;
+
+namespace FishNet.Transporting.Edgegap
+{
+    [DisallowMultipleComponent]
+    [AddComponentMenu("FishNet/Transport/EdgegapTransport")]
+    public class EdgegapTransport : Transport
+    {
+        ~EdgegapTransport()
+        {
+            Shutdown();
+        }
+
+        #region Serialized.
+        [Header("Channels")]
+        /// <summary>
+        /// Maximum transmission unit for the unreliable channel.
+        /// </summary>
+        [Tooltip("Maximum transmission unit for the unreliable channel.")]
+        [Range(MINIMUM_UDP_MTU, MAXIMUM_UDP_MTU)]
+        [SerializeField]
+        private int _unreliableMTU = MAXIMUM_UDP_MTU;
+
+        [Header("Relay")]
+        /// <summary>
+        /// The address of the relay
+        /// </summary>
+        [Tooltip("The address of the relay.")]
+        [SerializeField]
+        private string _relayAddress;
+        [Tooltip("The interval between ping messages to the relay.")]
+        [SerializeField]
+        private float _pingInterval = EdgegapProtocol.PingInterval;
+
+        [Tooltip("The user authorization token.")]
+        [SerializeField]
+        private uint _userAuthorizationToken;
+        [Tooltip("The session authorization token.")]
+        [SerializeField]
+        private uint _sessionAuthorizationToken;
+
+        [Header("Server")]
+        /// <summary>
+        /// Port to use.
+        /// </summary>
+        [Tooltip("Relay server port.")]
+        [SerializeField]
+        private ushort _relayServerPort;
+        /// <summary>
+        /// Maximum number of players which may be connected at once.
+        /// </summary>
+        [Tooltip("Maximum number of players which may be connected at once.")]
+        [Range(1, 9999)]
+        [SerializeField]
+        private int _maximumClients = 4095;
+
+
+        [Header("Client")]
+        /// <summary>
+        /// Address to connect.
+        /// </summary>
+        [Tooltip("Relay client port")]
+        [SerializeField]
+        private ushort _relayClientPort;
+
+        [Header("Misc")]
+        /// <summary>
+        /// How long in seconds until either the server or client socket must go without data before being timed out. Use 0f to disable timing out.
+        /// </summary>
+        [Tooltip("How long in seconds until either the server or client socket must go without data before being timed out. Use 0f to disable timing out.")]
+        [Range(0, MAX_TIMEOUT_SECONDS)]
+        [SerializeField]
+        private ushort _timeout = 15;
+        #endregion
+
+        #region Private.
+        /// <summary>
+        /// PacketLayer to use with LiteNetLib.
+        /// </summary>
+        private PacketLayerBase _packetLayer;
+        /// <summary>
+        /// Server socket and handler.
+        /// </summary>
+        private Server.EdgegapServerSocket _server = new Server.EdgegapServerSocket();
+        /// <summary>
+        /// Client socket and handler.
+        /// </summary>
+        private Client.EdgegapClientSocket _client = new Client.EdgegapClientSocket();
+
+        #endregion
+
+        #region Const.
+        private const ushort MAX_TIMEOUT_SECONDS = 1800;
+        /// <summary>
+        /// Minimum UDP packet size allowed.
+        /// </summary>
+        private const int MINIMUM_UDP_MTU = 576;
+        /// <summary>
+        /// Maximum UDP packet size allowed.
+        /// </summary>
+        private const int MAXIMUM_UDP_MTU = 1023;
+        #endregion
+
+        #region Initialization and unity.
+        public override void Initialize(NetworkManager networkManager, int transportIndex)
+        {
+            base.Initialize(networkManager, transportIndex);
+        }
+
+        protected void OnDestroy()
+        {
+            Shutdown();
+        }
+        #endregion
+
+        #region ConnectionStates.
+        /// <summary>
+        /// Gets the address of a remote connection Id.
+        /// </summary>
+        /// <param name="connectionId"></param>
+        /// <returns></returns>
+        public override string GetConnectionAddress(int connectionId)
+        {
+            return _server.GetConnectionAddress(connectionId);
+        }
+        /// <summary>
+        /// Called when a connection state changes for the local client.
+        /// </summary>
+        public override event Action<ClientConnectionStateArgs> OnClientConnectionState;
+        /// <summary>
+        /// Called when a connection state changes for the local server.
+        /// </summary>
+        public override event Action<ServerConnectionStateArgs> OnServerConnectionState;
+        /// <summary>
+        /// Called when a connection state changes for a remote client.
+        /// </summary>
+        public override event Action<RemoteConnectionStateArgs> OnRemoteConnectionState;
+        /// <summary>
+        /// Gets the current local ConnectionState.
+        /// </summary>
+        /// <param name="server">True if getting ConnectionState for the server.</param>
+        public override LocalConnectionState GetConnectionState(bool server)
+        {
+            if (server)
+                return _server.GetConnectionState();
+            else
+                return _client.GetConnectionState();
+        }
+        /// <summary>
+        /// Gets the current ConnectionState of a remote client on the server.
+        /// </summary>
+        /// <param name="connectionId">ConnectionId to get ConnectionState for.</param>
+        public override RemoteConnectionState GetConnectionState(int connectionId)
+        {
+            return _server.GetConnectionState(connectionId);
+        }
+        /// <summary>
+        /// Handles a ConnectionStateArgs for the local client.
+        /// </summary>
+        /// <param name="connectionStateArgs"></param>
+        public override void HandleClientConnectionState(ClientConnectionStateArgs connectionStateArgs)
+        {
+            OnClientConnectionState?.Invoke(connectionStateArgs);
+        }
+        /// <summary>
+        /// Handles a ConnectionStateArgs for the local server.
+        /// </summary>
+        /// <param name="connectionStateArgs"></param>
+        public override void HandleServerConnectionState(ServerConnectionStateArgs connectionStateArgs)
+        {
+            OnServerConnectionState?.Invoke(connectionStateArgs);
+            UpdateTimeout();
+        }
+        /// <summary>
+        /// Handles a ConnectionStateArgs for a remote client.
+        /// </summary>
+        /// <param name="connectionStateArgs"></param>
+        public override void HandleRemoteConnectionState(RemoteConnectionStateArgs connectionStateArgs)
+        {
+            OnRemoteConnectionState?.Invoke(connectionStateArgs);
+        }
+        #endregion
+
+        #region Iterating.
+        /// <summary>
+        /// Processes data received by the socket.
+        /// </summary>
+        /// <param name="server">True to process data received on the server.</param>
+        public override void IterateIncoming(bool server)
+        {
+            if (server)
+                _server.IterateIncoming();
+            else
+                _client.IterateIncoming();
+        }
+
+        /// <summary>
+        /// Processes data to be sent by the socket.
+        /// </summary>
+        /// <param name="server">True to process data received on the server.</param>
+        public override void IterateOutgoing(bool server)
+        {
+            if (server)
+                _server.IterateOutgoing();
+            else
+                _client.IterateOutgoing();
+        }
+        #endregion
+
+        #region ReceivedData.
+        /// <summary>
+        /// Called when client receives data.
+        /// </summary>
+        public override event Action<ClientReceivedDataArgs> OnClientReceivedData;
+        /// <summary>
+        /// Handles a ClientReceivedDataArgs.
+        /// </summary>
+        /// <param name="receivedDataArgs"></param>
+        public override void HandleClientReceivedDataArgs(ClientReceivedDataArgs receivedDataArgs)
+        {
+            OnClientReceivedData?.Invoke(receivedDataArgs);
+        }
+        /// <summary>
+        /// Called when server receives data.
+        /// </summary>
+        public override event Action<ServerReceivedDataArgs> OnServerReceivedData;
+        /// <summary>
+        /// Handles a ClientReceivedDataArgs.
+        /// </summary>
+        /// <param name="receivedDataArgs"></param>
+        public override void HandleServerReceivedDataArgs(ServerReceivedDataArgs receivedDataArgs)
+        {
+            OnServerReceivedData?.Invoke(receivedDataArgs);
+        }
+        #endregion
+
+        #region Sending.
+        /// <summary>
+        /// Sends to the server or all clients.
+        /// </summary>
+        /// <param name="channelId">Channel to use.</param>
+        /// <param name="segment">Data to send.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public override void SendToServer(byte channelId, ArraySegment<byte> segment)
+        {
+            SanitizeChannel(ref channelId);
+            _client.SendToServer(channelId, segment);
+        }
+        /// <summary>
+        /// Sends data to a client.
+        /// </summary>
+        /// <param name="channelId"></param>
+        /// <param name="segment"></param>
+        /// <param name="connectionId"></param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public override void SendToClient(byte channelId, ArraySegment<byte> segment, int connectionId)
+        {
+            SanitizeChannel(ref channelId);
+            _server.SendToClient(channelId, segment, connectionId);
+        }
+        #endregion
+
+        #region Configuration.
+        
+        /// <summary>
+        /// How long in seconds until either the server or client socket must go without data before being timed out.
+        /// </summary>
+        /// <param name="asServer">True to get the timeout for the server socket, false for the client socket.</param>
+        /// <returns></returns>
+        public override float GetTimeout(bool asServer)
+        {
+            //Server and client uses the same timeout.
+            return (float)_timeout;
+        }
+        /// <summary>
+        /// Sets how long in seconds until either the server or client socket must go without data before being timed out.
+        /// </summary>
+        /// <param name="asServer">True to set the timeout for the server socket, false for the client socket.</param>
+        public override void SetTimeout(float value, bool asServer)
+        {
+            _timeout = (ushort)value;
+        }
+        /// <summary>
+        /// Returns the maximum number of clients allowed to connect to the server. If the transport does not support this method the value -1 is returned.
+        /// </summary>
+        /// <returns></returns>
+        public override int GetMaximumClients()
+        {
+            return _server.GetMaximumClients();
+        }
+        /// <summary>
+        /// Sets maximum number of clients allowed to connect to the server. If applied at runtime and clients exceed this value existing clients will stay connected but new clients may not connect.
+        /// </summary>
+        /// <param name="value"></param>
+        public override void SetMaximumClients(int value)
+        {
+            _maximumClients = value;
+            _server.SetMaximumClients(value);
+        }
+
+        /// <summary>
+        /// Sets the adress and port/s of the relay. Doesn't affect the transport at runtime.
+        /// These can be retrieved using the Edgegap Relay API
+        /// </summary>
+        /// <param name="address">The IP address or fqdn of the relay to use</param>
+        /// <param name="clientPort">The port used to send client messages to the relay. Use 0 to ignore./param>
+        /// <param name="serverPort">The port used to send server messages to the relay. Use 0 to ignore.</param>
+        public void SetRelayEndpoint(string address, ushort clientPort = 0, ushort serverPort = 0)
+        {
+            _relayAddress = address;
+            _relayClientPort = clientPort != 0 ? clientPort : _relayClientPort;
+            _relayServerPort = serverPort != 0 ? serverPort : _relayClientPort;
+        }
+
+        /// <summary>
+        /// Sets the interval between ping messages to the relay.
+        /// </summary>
+        /// <param name="interval">The interval. The lower the interval the faster the authorization but the higher the overhead.</param>
+        public void SetPingInterval(int interval)
+        {
+            _pingInterval = interval;
+        }
+
+        /// <summary>
+        /// Sets the authorization headers required by the relay.
+        /// These can be retrieved using the Edgegap Relay API
+        /// </summary>
+        /// <param name="userAuth">The user authorization token</param>
+        /// <param name="sessionAuth">The session authorization token</param>
+        public void SetRelayAuth(uint userAuth, uint sessionAuth)
+        {
+            _userAuthorizationToken = userAuth;
+            _sessionAuthorizationToken = sessionAuth;
+        }
+
+        #endregion
+        #region Start and stop.
+        /// <summary>
+        /// Starts the local server or client using configured settings.
+        /// </summary>
+        /// <param name="server">True to start server.</param>
+        public override bool StartConnection(bool server)
+        {
+            if (server)
+                return StartServer();
+            else
+                return StartClient(_relayAddress);
+        }
+
+        /// <summary>
+        /// Stops the local server or client.
+        /// </summary>
+        /// <param name="server">True to stop server.</param>
+        public override bool StopConnection(bool server)
+        {
+            if (server)
+                return StopServer();
+            else
+                return StopClient();
+        }
+
+        /// <summary>
+        /// Stops a remote client from the server, disconnecting the client.
+        /// </summary>
+        /// <param name="connectionId">ConnectionId of the client to disconnect.</param>
+        /// <param name="immediately">True to abrutly stop the client socket. The technique used to accomplish immediate disconnects may vary depending on the transport.
+        /// When not using immediate disconnects it's recommended to perform disconnects using the ServerManager rather than accessing the transport directly.
+        /// </param>
+        public override bool StopConnection(int connectionId, bool immediately)
+        {
+            return _server.StopConnection(connectionId);
+        }
+
+        /// <summary>
+        /// Stops both client and server.
+        /// </summary>
+        public override void Shutdown()
+        {
+            //Stops client then server connections.
+            StopConnection(false);
+            StopConnection(true);
+        }
+
+        #region Privates.
+        /// <summary>
+        /// Starts server.
+        /// </summary>
+        private bool StartServer()
+        {
+            _server.Initialize(this, _unreliableMTU);
+            UpdateTimeout();
+            return _server.StartConnection(_relayAddress, _relayServerPort, _userAuthorizationToken, _sessionAuthorizationToken, _maximumClients);
+        }
+
+        /// <summary>
+        /// Stops server.
+        /// </summary>
+        private bool StopServer()
+        {
+            if (_server == null)
+                return false;
+            else
+                return _server.StopConnection();
+        }
+
+        /// <summary>
+        /// Starts the client.
+        /// </summary>
+        /// <param name="address"></param>
+        private bool StartClient(string address)
+        {
+            _client.Initialize(this, _unreliableMTU);
+            UpdateTimeout();
+            return _client.StartConnection(_relayAddress, _relayClientPort, _userAuthorizationToken, _sessionAuthorizationToken);
+        }
+
+        /// <summary>
+        /// Updates clients timeout values.
+        /// </summary>
+        private void UpdateTimeout()
+        {
+            //If server is running set timeout to max. This is for host only.
+            //int timeout = (GetConnectionState(true) != LocalConnectionState.Stopped) ? MAX_TIMEOUT_SECONDS : _timeout;
+            int timeout = (Application.isEditor) ? MAX_TIMEOUT_SECONDS : _timeout;
+            _client.UpdateTimeout(timeout);
+            _server.UpdateTimeout(timeout);
+        }
+        /// <summary>
+        /// Stops the client.
+        /// </summary>
+        private bool StopClient()
+        {
+            if (_client == null)
+                return false;
+            else
+                return _client.StopConnection();
+        }
+        #endregion
+        #endregion
+
+        #region Channels.
+        /// <summary>
+        /// If channelId is invalid then channelId becomes forced to reliable.
+        /// </summary>
+        /// <param name="channelId"></param>
+        private void SanitizeChannel(ref byte channelId)
+        {
+            if (channelId < 0 || channelId >= TransportManager.CHANNEL_COUNT)
+            {
+                NetworkManager.LogWarning($"Channel of {channelId} is out of range of supported channels. Channel will be defaulted to reliable.");
+                channelId = 0;
+            }
+        }
+        /// <summary>
+        /// Gets the MTU for a channel. This should take header size into consideration.
+        /// For example, if MTU is 1200 and a packet header for this channel is 10 in size, this method should return 1190.
+        /// </summary>
+        /// <param name="channel"></param>
+        /// <returns></returns>
+        public override int GetMTU(byte channel)
+        {
+            return _unreliableMTU;
+        }
+        #endregion
+
+        #region Editor.
+#if UNITY_EDITOR
+        private void OnValidate()
+        {
+            if (_unreliableMTU < 0)
+                _unreliableMTU = MINIMUM_UDP_MTU;
+            else if (_unreliableMTU > MAXIMUM_UDP_MTU)
+                _unreliableMTU = MAXIMUM_UDP_MTU;
+        }
+#endif
+        #endregion
+    }
+}


### PR DESCRIPTION
This PR adds the EdgegapTransport for fishnet.

This transport is heavily based on the Tugboat transport (the default for Fishnet).
The main changes are:
1. Using LiteNetLib packet layers for the Client/Server to pack/unpack the Relay headers
2. Send relay pings from Client/ServerSocket
3. Relay states will be mirrored to LocalConnectionStates

The transport can also be configured to use localhost rather than the relay for host mode.
The server can be supplied a local bind port such that direct P2P connection should also be supported.